### PR TITLE
README: Instruct users to clone the repository before creating a kind cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ You will need the following tools installed before proceeding:
 
 ## Setup
 
+Before running the following commands, ensure the repository has been cloned locally:
+
+```bash
+git clone https://github.com/isovalent/cilium-grafana-observability-demo
+```
+
 We're going to use [KIND](https://kind.sigs.k8s.io) to setup our Kubernetes cluster.
 All you need is access to a host running Docker.
 


### PR DESCRIPTION
The setup instructions instruct users to create a kind cluster using a
custom configuration that's stored in the remote git repository. Update
the instructions to clone the repository locally to avoid having to
copy/paste the custom kind config locally while following the README.